### PR TITLE
Cleaner client representation and docs fixes

### DIFF
--- a/docs/source/usecases/create_trainingset.rst
+++ b/docs/source/usecases/create_trainingset.rst
@@ -13,7 +13,7 @@ alphabet including dash and underscore: ``[-A-Za-z_-]``
 
 .. code-block:: python
 
-    training_set_version = client.create_training_set_version(
+    training_set_version = TrainingSetClient.create_training_set_version(
         training_set_name=training_set_name,
         df=my_df,
         key_columns=["user_id", "transaction_id"],

--- a/docs/source/usecases/delete_trainingset.rst
+++ b/docs/source/usecases/delete_trainingset.rst
@@ -8,7 +8,7 @@ Delete TrainingSetVersion
 
 .. code-block:: python
 
-    client.delete_training_set_version("my-training-set", 2)
+    TrainingSetClient.delete_training_set_version("my-training-set", 2)
 
 Delete TrainingSet
 ------------------
@@ -17,18 +17,18 @@ TrainingSets may only be deleted if they have no versions.
 
 .. code-block:: python
 
-    client.delete_training_set("my-training-set")
+    TrainingSetClient.delete_training_set("my-training-set")
 
 
 To delete the TrainingSet and all versions:
 
 .. code-block:: python
 
-    found_tsvs = client.list_training_set_versions(
+    found_tsvs = TrainingSetClient.list_training_set_versions(
         training_set_name="my-training-set",
     )
 
     for tsv in found_tsvs:
-        client.delete_training_set_version(tsv.training_set_name, tsv.number)
+        TrainingSetClient.delete_training_set_version(tsv.training_set_name, tsv.number)
 
-    client.delete_training_set("my-training-set")
+    TrainingSetClient.delete_training_set("my-training-set")

--- a/docs/source/usecases/get_trainingset.rst
+++ b/docs/source/usecases/get_trainingset.rst
@@ -10,7 +10,7 @@ TrainingSetVersions may be retrieved by name and number.
 
 .. code-block:: python
 
-    tsv_by_num = client.get_training_set_version(
+    tsv_by_num = TrainingSetClient.get_training_set_version(
         training_set_name="my-training-set",
         number=2,
     )
@@ -36,7 +36,7 @@ metadata, and TrainingSetVersion metadata. Results matching all search fields wi
 
 .. code-block:: python
 
-    versions = client.list_training_set_versions(
+    versions = TrainingSetClient.list_training_set_versions(
         training_set_name="my-training-set",
         meta={"year": "2021"},
         training_set_meta={"category": "widgets"}
@@ -50,7 +50,7 @@ TrainingSets may be retrieved by name.
 
 .. code-block:: python
 
-   ts = client.get_training_set("my-training-set")
+   ts = TrainingSetClient.get_training_set("my-training-set")
 
 Find TrainingSets
 -----------------
@@ -59,6 +59,6 @@ TrainingSets may be searched for by metadata. Results matching all metadata fiel
 
 .. code-block:: python
 
-   ts = client.list_training_sets(
+   ts = TrainingSetClient.list_training_sets(
        meta={"category": "widgets"},
    )

--- a/docs/source/usecases/update_trainingset.rst
+++ b/docs/source/usecases/update_trainingset.rst
@@ -8,12 +8,12 @@ Update TrainingSet
 
 .. code-block:: python
 
-    ts = client.get_training_set("my-training-set")
+    ts = TrainingSetClient.get_training_set("my-training-set")
 
     ts.description = "widget transactions"
     ts.metadata.update({"region": "west"})
 
-    updated = client.update_training_set(ts)
+    updated = TrainingSetClient.update_training_set(ts)
 
 
 Update TrainingSetVersion
@@ -21,9 +21,9 @@ Update TrainingSetVersion
 
 .. code-block:: python
 
-    tsv = client.get_training_set_version("my-training-set", 2)
+    tsv = TrainingSetClient.get_training_set_version("my-training-set", 2)
 
     tsv.description = "2020 transactions"
     tsv.metadata.update({"status": "final"})
 
-    updated = client.update_training_set_version(tsv)
+    updated = TrainingSetClient.update_training_set_version(tsv)

--- a/domino_data/data_sources.py
+++ b/domino_data/data_sources.py
@@ -508,9 +508,9 @@ class BoardingPass:
 class DataSourceClient:
     """API client and bindings."""
 
-    domino: AuthenticatedClient = attr.ib(init=False)
-    proxy: flight.FlightClient = attr.ib(init=False)
-    proxy_http: AuthenticatedClient = attr.ib(init=False)
+    domino: AuthenticatedClient = attr.ib(init=False, repr=False)
+    proxy: flight.FlightClient = attr.ib(init=False, repr=False)
+    proxy_http: AuthenticatedClient = attr.ib(init=False, repr=False)
 
     api_key: Optional[str] = attr.ib(factory=lambda: os.getenv("DOMINO_USER_API_KEY"))
     token_file: Optional[str] = attr.ib(factory=lambda: os.getenv("DOMINO_TOKEN_FILE"))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "dominodatalab-data"
-version = "0.1.4"
+version = "0.1.5"
 description = "Domino Data SDK for interacting with Access Data features"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Description

Use `TrainingSetClient` instead of `client` in docs about Training Sets

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CONTRIBUTING.md`](https://github.com/dominodatalab/datasdk/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
