### PR TITLE
Add missing comma and clarify import information

### DIFF
--- a/docs/source/usecases/create_trainingset.rst
+++ b/docs/source/usecases/create_trainingset.rst
@@ -12,8 +12,7 @@ TrainingSet names must be strings containing only alphanumeric characters in the
 alphabet including dash and underscore: ``[-A-Za-z_-]``
 
 .. code-block:: python
-    from domino_data.training_sets import client as TrainingSetClient
-    from domino_data.training_sets import model
+    from domino.training_sets import TrainingSetClient, model
     
     training_set_version = TrainingSetClient.create_training_set_version(
         training_set_name=training_set_name,


### PR DESCRIPTION
The example code for creating a Training Set is not readily usable by those who might wish to copy/paste it or use it as a template. I have taken strides here to improve its usability as such.

There was also a syntax error from a missing comma, so I put that in there, too.

## Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/dominodatalab/datasdk/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
