### PR TITLE
Add note on monitoring_meta keyword argument

### DIFF
--- a/docs/source/usecases/create_trainingset.rst
+++ b/docs/source/usecases/create_trainingset.rst
@@ -32,6 +32,7 @@ alphabet including dash and underscore: ``[-A-Za-z_-]``
 Note that you are unable to use a TrainingSet for model monitoring unless you providing a value for
 the ``monitoring_meta`` keyword argument. You can still create a TrainingSet without this argument,
 but TrainingSets created without the ``monitoring_meta`` keyword argument cannot be used for model
-monitoring. If you try to use a Training Set created without the ``monitoring_meta`` keyword
-argument, you will see the error ``The selected Feature Set Version cannot currently be used for
+monitoring. If you select a Training Set created without the ``monitoring_meta`` keyword
+argument while trying to register a Model API for monitoring from the Monitoring tab of the page
+for that Model API, then you will see the error ``The selected Feature Set Version cannot currently be used for
 monitoring because it does not contain a schema definition.``


### PR DESCRIPTION
## Description
I discovered the hard way that just creating a TrainingSet isn't enough.
You have to include an optional keyword argument, as well.
And it can't be empty, either, but I'm not sure how nonempty it has to be.
Additionally, failure to include this keyword argument results in a downstream
error that is not at all helpful in informing the user what corrective action
needs to be taken, so I have mentioned that error here in the hopes it might
inform seekers who would solve this problem that this is the source of it.

Note that there's no clear path to this documentation as of yet, so I'm not sure
how seekers would get close enough to search for this page and find it, but it's
at least here for when they do.
<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/dominodatalab/datasdk/blob/master/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
