### PR TITLE
Fix documentation typos

### DIFF
--- a/docs/source/usecases/config_override.rst
+++ b/docs/source/usecases/config_override.rst
@@ -6,7 +6,7 @@ Permanent vs local change
 
 Datasource configuration are set in the Data/Datasource panel of the Domino UI. You can update it there for any permanent change.
 
-Some configuration attributes can be overriden locally in the SDK. Each datasource type config is described in the section below (:ref:`configs`).
+Some configuration attributes can be overridden locally in the SDK. Each datasource type config is described in the section below (:ref:`configs`).
 
 Usage
 -----

--- a/domino_data/data_sources.py
+++ b/domino_data/data_sources.py
@@ -169,7 +169,7 @@ class SnowflakeConfig(Config):
 
 @attr.s(auto_attribs=True)
 class S3Config(Config):
-    """S3 datasource configurationn."""
+    """S3 datasource configuration."""
 
     bucket: Optional[str] = _config(elem=ConfigElem.BUCKET)
     region: Optional[str] = _config(elem=ConfigElem.REGION)


### PR DESCRIPTION
## Description

Documentation typos discovered by https://www.triplechecker.com/reports

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix