### PR TITLE
Surface descriptive errors in training sets create flow

### DIFF
--- a/domino_data/training_sets/client.py
+++ b/domino_data/training_sets/client.py
@@ -266,7 +266,7 @@ def create_training_set_version(
     )
 
     if response.status_code != 200:
-        _raise_response_exn(response, "could not create TrainingSetVersion")
+        _raise_response_exn(response, response.text)
 
     tsv = _to_TrainingSetVersion(response.parsed)
 


### PR DESCRIPTION
## Description
Errors thrown in nucleus have descriptive error messages but are not surfaced 

## Related Issue
https://dominodatalab.atlassian.net/browse/DOM-36662
