### PR TITLE
Replace mentions of `SDK` by `API` in the documentation

### DIFF
--- a/docs/source/auth.rst
+++ b/docs/source/auth.rst
@@ -8,7 +8,7 @@ Authentication
 Methods
 -------
 
-Using the SDK there are two methods available for authentication:
+There are two authentication methods available when using the Domino Data API:
 
 * **Credential propagation:** A token is periodically refreshed and stored in a file. The file location is defined in the **DOMINO_TOKEN_FILE** env variable
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -1,22 +1,22 @@
 .. _install:
 
-Install the Data SDK
+Install the Data API
 ====================
 
-You can use the SDK by using the right Domino environment. If you want to install it manually with **pip** we highly recommand installing it as an extra dependency of the main `python domino package <https://github.com/dominodatalab/python-domino>`_.
+You can use the API by using the right Domino environment. If you want to install it manually with **pip** we highly recommand installing it as an extra dependency of the main `python domino package <https://github.com/dominodatalab/python-domino>`_.
 
 Domino Standard Environment
 ---------------------------
 
-The Data SDK comes pre-packaged in the `Domino Standard Environment (DSE) <https://docs.dominodatalab.com/en/5.0/reference/environments/Domino_4_standard_environments.html>`_ starting version 5.0.
+The Data API comes pre-packaged in the `Domino Standard Environment (DSE) <https://docs.dominodatalab.com/en/5.0/reference/environments/Domino_4_standard_environments.html>`_ starting version 5.0.
 
-If you want to use your own environment, you can easily install the SDK by adding the following to the *Dockefile Instructions* section:
+If you want to use your own environment, you can easily install the API by adding the following to the *Dockefile Instructions* section:
 
 .. code-block:: docker
 
    USER root
 
-   ## Install Domino and Data SDK packages
+   ## Install Domino and Data API packages
    RUN python -m pip install dominodatalab[data]
 
    USER ubuntu
@@ -25,13 +25,13 @@ Python Package Index (PyPI)
 ---------------------------
 
 .. note::
-    If you use the SDK as a standalone library, the package name will be `domino_data`. We recommand installing it as part of the main domino package for easier and consistent import (see :ref:`usecase-simple-query` for an example)
+    If you use the API as a standalone library, the package name will be `domino_data`. We recommand installing it as part of the main domino package for easier and consistent import (see :ref:`usecase-simple-query` for an example)
 
 .. code-block:: console
 
    $ python -m pip install dominodatalab[data]
 
-If you only want the Data SDK, it is published in `PyPI <https://pypi.org/project/dominodatalab-data>`_:
+If you only want the Data API, it is published in `PyPI <https://pypi.org/project/dominodatalab-data>`_:
 
 .. code-block:: console
 

--- a/docs/source/usecases/config_override.rst
+++ b/docs/source/usecases/config_override.rst
@@ -6,7 +6,7 @@ Permanent vs local change
 
 Datasource configuration are set in the Data/Datasource panel of the Domino UI. You can update it there for any permanent change.
 
-Some configuration attributes can be overridden locally in the SDK. Each datasource type config is described in the section below (:ref:`configs`).
+Some configuration attributes can be overridden locally in the API. Each datasource type config is described in the section below (:ref:`configs`).
 
 Usage
 -----

--- a/docs/source/usecases/object_store.rst
+++ b/docs/source/usecases/object_store.rst
@@ -6,7 +6,7 @@ Object store
 Datasource type
 ---------------
 
-The SDK supports object store type datasources (S3) and allows for easy retrieval and upload of objects. **Note:** The following APIs are only available when using this type of datasource.
+The API supports object store type datasources (S3) and allows for easy retrieval and upload of objects. **Note:** The following APIs are only available when using this type of datasource.
 
 
 List
@@ -103,5 +103,3 @@ You can also write from the object entity.
    # Upload content from file-like object
    f = io.BytesIO()
    my_key.upload_fileobj(f)
-
-

--- a/docs/source/usecases/simple_query.rst
+++ b/docs/source/usecases/simple_query.rst
@@ -8,7 +8,7 @@ Tabular store
 Setup
 -----
 
-**Note:** Ensure that the SDK is available in your workspace environment, see :ref:`install` for setup information.
+**Note:** Ensure that the API is available in your workspace environment, see :ref:`install` for setup information.
 
 Authentication
 --------------


### PR DESCRIPTION
## Description

Using the term `SDK` has been removed in favor of `API`

## Related Issue

Parts of the documentation were still referring to the python library as `SDK`

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CONTRIBUTING.md`](https://github.com/dominodatalab/domino-data/blob/main/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
