### PR TITLE
IAM Credential prop SDK support for session

### DIFF
--- a/domino_data/data_sources.py
+++ b/domino_data/data_sources.py
@@ -214,6 +214,7 @@ class RedshiftConfig(Config):
     aws_secret_access_key: Optional[str] = _cred(elem=CredElem.PASSWORD)
     session: Optional[str] = _cred(elem=CredElem.SESSION)
 
+
 @attr.s(auto_attribs=True)
 class SnowflakeConfig(Config):
     """Snowflake datasource configuration."""
@@ -464,9 +465,7 @@ class Datasource:
             # TODO: grab location from meta
             location = "DOMINO_TOKEN_FILE"
             credentials = self._load_oauth_token(location)
-        elif (
-            self.auth_type == DatasourceDtoAuthType.AWSIAMROLE.value
-        ):
+        elif self.auth_type == DatasourceDtoAuthType.AWSIAMROLE.value:
             # TODO: grab location from meta
             location = "AWS_SHARED_CREDENTIALS_FILE"
             credentials = self._load_aws_credentials(location)
@@ -497,7 +496,7 @@ class Datasource:
         return dict(
             username=aws_config.get(profile, "aws_access_key_id"),
             password=aws_config.get(profile, "aws_secret_access_key"),
-            session=aws_config.get(profile, "aws_session_token")
+            session=aws_config.get(profile, "aws_session_token"),
         )
 
     def update(self, config: DatasourceConfig) -> None:

--- a/tests/data/aws_credentials
+++ b/tests/data/aws_credentials
@@ -1,3 +1,4 @@
 [default]
 aws_access_key_id=AKIAIOSFODNN7EXAMPLE
 aws_secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+aws_session_token=FwoGZXIvYXdzENr//////////verylongandbig

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -534,6 +534,7 @@ def test_credential_override_with_awsiamrole(respx_mock, datafx, monkeypatch):
     # values in file
     assert list_creds["username"] == "AKIAIOSFODNN7EXAMPLE"
     assert list_creds["password"] == "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+    assert list_creds["session"] == "FwoGZXIvYXdzENr//////////verylongandbig"
     assert get_key_url_creds["username"] == "AKIAIOSFODNN7EXAMPLE"
     assert get_key_url_creds["password"] == "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
 


### PR DESCRIPTION
## Description
SDK tweaks for AWS credential propagation
-add session token
-change conditional for loading aws credentials
-test changes

## Related Issue
https://dominodatalab.atlassian.net/browse/DOM-36202