### PR TITLE
Override import to find configs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/domino_data/data_sources.py
+++ b/domino_data/data_sources.py
@@ -1,6 +1,7 @@
 """Datasource module."""
 from typing import Any, Dict, List, Optional, cast
 
+import builtins
 import configparser
 import json
 import os
@@ -11,6 +12,7 @@ import httpx
 import pandas
 from pyarrow import ArrowException, flight, parquet
 
+import domino_data.configuration_gen
 from datasource_api_client.api.datasource import get_datasource_by_name
 from datasource_api_client.api.proxy import get_key_url, list_keys, log_metric
 from datasource_api_client.models import DatasourceConfig as APIConfig
@@ -42,6 +44,17 @@ AWS_CREDENTIALS_DEFAULT_LOCATION = "/var/lib/domino/home/.aws/credentials"
 AWS_SHARED_CREDENTIALS_FILE = "AWS_SHARED_CREDENTIALS_FILE"
 DOMINO_TOKEN_DEFAULT_LOCATION = "/var/lib/domino/home/.api/token"
 DOMINO_TOKEN_FILE = "DOMINO_TOKEN_FILE"
+
+
+def __getattr__(name: str) -> Any:
+    if name.endswith("Config"):
+        return getattr(domino_data.configuration_gen, name)
+    raise AttributeError(f"module {__name__} has no attribute {name}")
+
+
+def __dir__() -> List[str]:
+    confs = filter(lambda x: x.endswith("Config"), dir(domino_data.configuration_gen))
+    return builtins.dir() + list(confs)
 
 
 class DominoError(Exception):

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -289,7 +289,7 @@ def test_config_returns_overrides():
     """Config returns override for changed fields only."""
 
     @ds.attr.s(auto_attribs=True)
-    class DummyConfig(ds_gen.Config):
+    class DummyConfig(ds.Config):
         """Dummy Config"""
 
         # pylint: disable=protected-access
@@ -318,7 +318,7 @@ def test_config_returns_overrides():
 def test_mysql_config():
     """MySQL config serializes to expected keys."""
 
-    mysql = ds_gen.MySQLConfig(database="dev2", username="awsadmin", password="protec")
+    mysql = ds.MySQLConfig(database="dev2", username="awsadmin", password="protec")
 
     assert mysql.config() == {"database": "dev2"}
     assert mysql.credential() == {"username": "awsadmin", "password": "protec"}
@@ -327,7 +327,7 @@ def test_mysql_config():
 def test_postgresql_config():
     """PostgreSQL config serializes to expected keys."""
 
-    postgres = ds_gen.PostgreSQLConfig(
+    postgres = ds.PostgreSQLConfig(
         database="dev2",
         username="awsadmin",
         password="protec",
@@ -340,7 +340,7 @@ def test_postgresql_config():
 def test_redshift_config():
     """Redshift config serializes to expected keys."""
 
-    red = ds_gen.RedshiftConfig(database="dev2", username="awsadmin", password="protec")
+    red = ds.RedshiftConfig(database="dev2", username="awsadmin", password="protec")
 
     assert red.config() == {"database": "dev2"}
     assert red.credential() == {"username": "awsadmin", "password": "protec"}
@@ -349,7 +349,7 @@ def test_redshift_config():
 def test_snowflake_config():
     """Snowflake config serializes to expected keys."""
 
-    snow = ds_gen.SnowflakeConfig(
+    snow = ds.SnowflakeConfig(
         database="winter",
         schema="private",
         warehouse="xxl",
@@ -369,7 +369,7 @@ def test_snowflake_config():
 
 def test_oracle_config():
     """Oracle config serializes to expected keys."""
-    orcl = ds_gen.OracleConfig(database="dev2", username="awsadmin", password="protec")
+    orcl = ds.OracleConfig(database="dev2", username="awsadmin", password="protec")
 
     assert orcl.config() == {"database": "dev2"}
     assert orcl.credential() == {"username": "awsadmin", "password": "protec"}
@@ -377,7 +377,7 @@ def test_oracle_config():
 
 def test_s3_config():
     """S3 config serializes to expected keys."""
-    s3c = ds_gen.S3Config(
+    s3c = ds.S3Config(
         bucket="sceau",
         region="midi-pyrenees",
         aws_access_key_id="identite",
@@ -391,7 +391,7 @@ def test_s3_config():
 def test_sqlserver_config():
     """SQL Server config serializes to expected keys."""
 
-    sqlServer = ds_gen.SQLServerConfig(database="dev2", username="awsadmin", password="protec")
+    sqlServer = ds.SQLServerConfig(database="dev2", username="awsadmin", password="protec")
 
     assert sqlServer.config() == {"database": "dev2"}
     assert sqlServer.credential() == {"username": "awsadmin", "password": "protec"}
@@ -400,7 +400,7 @@ def test_sqlserver_config():
 def test_gcp_config():
     """GCP config serializes to expected keys."""
 
-    gcsc = ds_gen.GCSConfig(
+    gcsc = ds.GCSConfig(
         bucket="cestino",
         private_key_json="chiave-segreta",
     )


### PR DESCRIPTION
## Description

Config objects weren't imported properly since they move to `configuration_gen`

## Related Issue

https://dominodatalab.atlassian.net/browse/DOM-38900

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CONTRIBUTING.md`](https://github.com/dominodatalab/domino-data/blob/main/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
