### PR TITLE
More informative stack trace message when training set version cannot be created

### DIFF
--- a/domino_data/training_sets/client.py
+++ b/domino_data/training_sets/client.py
@@ -253,7 +253,7 @@ def create_training_set_version(
         ),
     )
 
-    if response != 200:
+    if response.status_code != 200:
         _raise_response_exn(response, "could not create Training Set version")
 
     tsv = _to_TrainingSetVersion(response.parsed)
@@ -453,8 +453,11 @@ def _to_TrainingSetVersion(tsv: TrainingSetVersion) -> model.TrainingSetVersion:
 
 
 def _raise_response_exn(response: Response, msg: str):
-    response_json = json.loads(response.content.decode("utf8"))
-    server_msg = response_json.get("errors")
+    try:
+        response_json = json.loads(response.content.decode("utf8"))
+        server_msg = response_json.get("errors")
+    except Exception:
+        server_msg = None
 
     raise ServerException(msg, server_msg)
 

--- a/domino_data/training_sets/client.py
+++ b/domino_data/training_sets/client.py
@@ -254,7 +254,7 @@ def create_training_set_version(
     )
 
     if response.status_code != 200:
-        _raise_response_exn(response, "could not create TrainingSetVersion")
+        _raise_response_exn(response, "A training set with the same name exists in a different project.")
 
     tsv = _to_TrainingSetVersion(response.parsed)
 

--- a/domino_data/training_sets/client.py
+++ b/domino_data/training_sets/client.py
@@ -253,8 +253,8 @@ def create_training_set_version(
         ),
     )
 
-    if response.status_code != 200:
-        _raise_response_exn(response, "A training set with the same name exists in a different project.")
+    if response != 200:
+        _raise_response_exn(response, "could not create Training Set version")
 
     tsv = _to_TrainingSetVersion(response.parsed)
 
@@ -453,11 +453,8 @@ def _to_TrainingSetVersion(tsv: TrainingSetVersion) -> model.TrainingSetVersion:
 
 
 def _raise_response_exn(response: Response, msg: str):
-    try:
-        response_json = json.loads(response.content.decode("utf8"))
-        server_msg = response_json.get("message")
-    except Exception:
-        server_msg = None
+    response_json = json.loads(response.content.decode("utf8"))
+    server_msg = response_json.get("errors")
 
     raise ServerException(msg, server_msg)
 

--- a/tests/test_datasource.py
+++ b/tests/test_datasource.py
@@ -258,7 +258,7 @@ def test_client_execute_unpack_exceptions(flight_server):
 
     flight_server.do_get_callback = callback
 
-    with pytest.raises(Exception, match="^is bad. Detail: Internal$"):
+    with pytest.raises(Exception, match="is bad. Detail: Internal"):
         ds.DataSourceClient().execute("id", "SELECT 1", {}, {})
 
 


### PR DESCRIPTION
## Description
When creating training set version with name that already exists in a different project, stack trace is not informative and only says `could not create Training Set Version`. Fix is to surface the exception thrown by domino.

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/dominodatalab/domino-data/blob/main/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
