### PR TITLE
[DOM-42475] Adding error message when user accesses SDK from remote data plane

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ mypy:
 check-safety:
 	poetry check
 	# TODO remove numpy ignore flag when fixed
-	poetry run safety check --full-report -i 44715
+	poetry run safety check --full-report -i 44715 -i 51668
 	poetry run bandit -ll --recursive domino_data tests
 
 .PHONY: lint

--- a/domino_data/data_sources.py
+++ b/domino_data/data_sources.py
@@ -527,7 +527,8 @@ class DataSourceClient:
         if is_local == "false":
             logging.warning(
                 "Data Sources are in beta for all Nexus enabled deployments, "
-                "so some functionality may not work as expected. Contact your Admin if you encounter any issues."
+                "so some functionality may not work as expected. "
+                "Contact your Admin if you encounter any issues."
             )
 
     def __attrs_post_init__(self):

--- a/domino_data/data_sources.py
+++ b/domino_data/data_sources.py
@@ -4,6 +4,7 @@ from typing import Any, Dict, List, Optional, cast
 import builtins
 import configparser
 import json
+import logging
 import os
 
 import attr
@@ -520,6 +521,14 @@ class DataSourceClient:
     api_key: Optional[str] = attr.ib(factory=lambda: os.getenv("DOMINO_USER_API_KEY"))
     token_file: Optional[str] = attr.ib(factory=lambda: os.getenv("DOMINO_TOKEN_FILE"))
     token_url: Optional[str] = attr.ib(factory=lambda: os.getenv("DOMINO_API_PROXY"))
+
+    def __attrs_pre_init__(self):
+        is_local = os.getenv("DOMINO_IS_LOCAL_DATA_PLANE")
+        if is_local == "false":
+            logging.warning(
+                "Data Sources are in beta for all Nexus enabled deployments, "
+                "so some functionality may not work as expected. Contact your Admin if you encounter any issues."
+            )
 
     def __attrs_post_init__(self):
         flight_host = os.getenv("DOMINO_DATASOURCE_PROXY_FLIGHT_HOST")


### PR DESCRIPTION
## Description

When user instantiates DataSourceClient in the remote data plane, a logging error will be displayed like this: 
<img width="1126" alt="Screen Shot 2022-12-09 at 2 06 58 PM" src="https://user-images.githubusercontent.com/110200460/206806119-d2d6a174-3e3d-4500-bada-fbaaefd0ce64.png">


## Related Issue

https://dominodatalab.atlassian.net/browse/DOM-42475

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [] 🥂 Improvement (non-breaking change which improves an existing feature)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/dominodatalab/domino-data/blob/main/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
