### PR TITLE
Fix for missing feature store error logs

### DIFF
--- a/domino_data/_feature_store/git.py
+++ b/domino_data/_feature_store/git.py
@@ -2,8 +2,8 @@
 
 from git import FetchInfo, PushInfo, Repo
 
-from ..logging import logger
 from .exceptions import GitPullError, GitPushError
+from .logging import logger
 
 _INVALID_PULL_FLAGS = [FetchInfo.ERROR, FetchInfo.REJECTED]
 _INVALID_PUSH_FLAGS = [

--- a/domino_data/_feature_store/logging.py
+++ b/domino_data/_feature_store/logging.py
@@ -1,30 +1,19 @@
-"""Logging module."""
+"""Dedicated Feature Store Logging module."""
 
 import os
 import sys
-import tempfile
 
 from loguru import logger as _logger
 
-LOGFILE_LOCATION = "domino_logs/data_api.log"
 
-
-def getsink():
-    """Return log sink location."""
-    return f"{tempfile.gettempdir()}/{LOGFILE_LOCATION}"
-
-
-def getlogger():
+def get_feature_store_logger():
     """Configure and return a logger."""
     _logger.configure(
         handlers=[
             {
                 "format": "[{time}] {message}",
-                "sink": getsink(),
-                "rotation": "1 day",
-                "retention": 7,
+                "sink": sys.stdout,
                 "enqueue": True,
-                "serialize": True,
             },
         ],
         extra={
@@ -37,4 +26,4 @@ def getlogger():
     return _logger
 
 
-logger = getlogger()
+logger = get_feature_store_logger()

--- a/domino_data/_feature_store/run.py
+++ b/domino_data/_feature_store/run.py
@@ -2,7 +2,7 @@
 import argparse
 import sys
 
-from ..logging import logger
+from .logging import logger
 from .sync import feature_store_sync
 
 if __name__ == "__main__":

--- a/domino_data/_feature_store/sync.py
+++ b/domino_data/_feature_store/sync.py
@@ -17,10 +17,10 @@ from feature_store_api_client.models import (
 )
 from feature_store_api_client.types import UNSET
 
-from ..logging import logger
 from .client import FeatureStoreClient
 from .exceptions import FeastRepoError, FeatureStoreLockError
 from .git import pull_repo, push_to_git
+from .logging import logger
 
 LOCK_FAILURE_MESSAGE = "Failed to lock feature store for syncing. Please rerun later."
 

--- a/domino_data/logging.py
+++ b/domino_data/logging.py
@@ -1,7 +1,6 @@
 """Logging module."""
 
 import os
-import sys
 import tempfile
 
 from loguru import logger as _logger

--- a/tests/feature_store/test_logging.py
+++ b/tests/feature_store/test_logging.py
@@ -1,0 +1,10 @@
+"""Feature store logging setup tests."""
+
+
+def test_logger_initialize_properly(monkeypatch):
+    """Ensure logger initialize without errors."""
+    monkeypatch.delenv("HOME")
+
+    from domino_data._feature_store import logging  # pylint: disable=import-outside-toplevel
+
+    logging.get_feature_store_logger()


### PR DESCRIPTION
## Description

The logging filter doesn't work well with exception logs.  Feature store exception logs can't be logged to the console.  We need logs to console so that it will be captures as job run result. So created a dedicated logger for feature store. 

## Related Issue
https://dominodatalab.atlassian.net/browse/DOM-43059

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/dominodatalab/domino-data/blob/main/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
