### PR TITLE
Increase timeout to Nucleus from 5 to 20s

### DIFF
--- a/domino_data/data_sources.py
+++ b/domino_data/data_sources.py
@@ -559,7 +559,7 @@ class DataSourceClient:
             token_file=self.token_file,
             token_url=self.token_url,
             headers=ACCEPT_HEADERS,
-            timeout=5.0,
+            timeout=20.0,
             verify_ssl=True,
         )
 


### PR DESCRIPTION
## Description

Increase timeout to avoid issues when using Data SDK in compute clusters

## Related Issue

https://dominodatalab.atlassian.net/browse/DOM-43367

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CONTRIBUTING.md`](https://github.com/dominodatalab/domino-data/blob/main/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
