### PR TITLE
DataSource Audit: pass run_id from env variable 

### DIFF
--- a/domino_data/auth.py
+++ b/domino_data/auth.py
@@ -69,9 +69,14 @@ class AuthenticatedClient(Client):
 class ProxyClient(AuthenticatedClient):
     """A client that authenticates all requests but with Proxy headers."""
 
+    run_id: Optional[str] = attr.ib()
+
     def get_headers(self) -> Dict[str, str]:
         if self.api_key:
             self.headers["X-Domino-Api-Key"] = self.api_key
+
+        if self.run_id:
+            self.headers["X-Domino-Run-Id"] = self.run_id
 
         if self.token_url is not None:
             try:

--- a/domino_data/data_sources.py
+++ b/domino_data/data_sources.py
@@ -48,9 +48,9 @@ DOMINO_API_HOST = "DOMINO_API_HOST"
 DOMINO_API_PROXY = "DOMINO_API_PROXY"
 DOMINO_DATASOURCE_PROXY_HOST = "DOMINO_DATASOURCE_PROXY_HOST"
 DOMINO_DATASOURCE_PROXY_FLIGHT_HOST = "DOMINO_DATASOURCE_PROXY_FLIGHT_HOST"
+DOMINO_RUN_ID = "DOMINO_RUN_ID"
 DOMINO_USER_API_KEY = "DOMINO_USER_API_KEY"
 DOMINO_USER_HOST = "DOMINO_USER_HOST"
-DOMINO_RUN_ID = "DOMINO_RUN_ID"
 DOMINO_TOKEN_DEFAULT_LOCATION = "/var/lib/domino/home/.api/token"
 DOMINO_TOKEN_FILE = "DOMINO_TOKEN_FILE"
 
@@ -594,6 +594,7 @@ class DataSourceClient:
         self.proxy_http = ProxyClient(
             base_url=proxy_host,
             api_key=self.api_key,
+            run_id=self.run_id,
             token_file=self.token_file,
             token_url=self.token_url,
             timeout=5.0,

--- a/domino_data/meta.py
+++ b/domino_data/meta.py
@@ -1,0 +1,39 @@
+""" Classes to augment headers with metadata for HTTP and Flight requests."""
+
+from typing import Optional
+
+import attr
+from pyarrow import flight
+
+
+@attr.s(auto_attribs=True)
+class MetaMiddlewareFactory(flight.ClientMiddlewareFactory):
+    """Middleware Factory for metadata."""
+
+    run_id: Optional[str] = attr.ib()
+
+    def start_call(self, _):
+        """Called at the start of an RPC."""
+        return MetaMiddleware(self.run_id)
+
+
+@attr.s(auto_attribs=True)
+class MetaMiddleware(flight.ClientMiddleware):
+    """Middleware for authenticating flight requests."""
+
+    run_id: Optional[str] = attr.ib()
+
+    def call_completed(self, _):
+        """No implementation. TODO logging."""
+
+    def received_headers(self, _):
+        """No implementation."""
+
+    def sending_headers(self):
+        """Return metadata headers."""
+        headers = {}
+
+        if self.run_id is not None:
+            headers["x-domino-run-id"] = self.run_id
+
+        return headers


### PR DESCRIPTION
## Description

DataSource Audit Trail: need to pass environment variable runId to proxy

## Related Issue

https://dominodatalab.atlassian.net/browse/DOM-48058

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/dominodatalab/domino-data/blob/main/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
