### PR TITLE
DataSource Audit: pass run_id from env variable

### DIFF
--- a/domino_data/auth.py
+++ b/domino_data/auth.py
@@ -69,9 +69,14 @@ class AuthenticatedClient(Client):
 class ProxyClient(AuthenticatedClient):
     """A client that authenticates all requests but with Proxy headers."""
 
+    run_id: Optional[str] = attr.ib()
+
     def get_headers(self) -> Dict[str, str]:
         if self.api_key:
             self.headers["X-Domino-Api-Key"] = self.api_key
+
+        if self.run_id:
+            self.headers["X-Domino-Run-Id"] = self.run_id
 
         if self.token_url is not None:
             try:

--- a/domino_data/auth.py
+++ b/domino_data/auth.py
@@ -69,12 +69,14 @@ class AuthenticatedClient(Client):
 class ProxyClient(AuthenticatedClient):
     """A client that authenticates all requests but with Proxy headers."""
 
+    client_source: Optional[str] = attr.ib()
     run_id: Optional[str] = attr.ib()
 
     def get_headers(self) -> Dict[str, str]:
         if self.api_key:
             self.headers["X-Domino-Api-Key"] = self.api_key
-
+        if self.client_source:
+            self.headers["X-Domino-Client-Source"] = self.client_source
         if self.run_id:
             self.headers["X-Domino-Run-Id"] = self.run_id
 

--- a/domino_data/data_sources.py
+++ b/domino_data/data_sources.py
@@ -625,7 +625,7 @@ class DataSourceClient:
                     self.token_file,
                     self.token_url,
                 ),
-                MetaMiddlewareFactory(client_source, run_id),
+                MetaMiddlewareFactory(client_source=client_source, run_id=run_id),
             ],
         )
 
@@ -647,7 +647,7 @@ class DataSourceClient:
         response = get_datasource_by_name.sync_detailed(
             name,
             client=self.domino,
-            run_id=run_id,  # TODO: consider also putting in headers?
+            run_id=run_id,
         )
         if response.status_code == 200:
             datasource_dto = cast(DatasourceDto, response.parsed)

--- a/domino_data/data_sources.py
+++ b/domino_data/data_sources.py
@@ -574,14 +574,13 @@ class DataSourceClient:
     token_file: Optional[str] = attr.ib(factory=lambda: os.getenv(DOMINO_TOKEN_FILE))
     token_url: Optional[str] = attr.ib(factory=lambda: os.getenv(DOMINO_API_PROXY))
 
-    run_id: Optional[str] = attr.ib(factory=lambda: os.getenv(DOMINO_RUN_ID))
-
     def __attrs_post_init__(self):
         flight_host = os.getenv(DOMINO_DATASOURCE_PROXY_FLIGHT_HOST)
         domino_host = os.getenv(
             DOMINO_API_PROXY, os.getenv(DOMINO_API_HOST, os.getenv(DOMINO_USER_HOST, ""))
         )
         proxy_host = os.getenv(DOMINO_DATASOURCE_PROXY_HOST, "")
+        run_id = os.getenv(DOMINO_RUN_ID, "")
 
         logger.info(
             "initializing datasource client with hosts",
@@ -594,7 +593,7 @@ class DataSourceClient:
         self.proxy_http = ProxyClient(
             base_url=proxy_host,
             api_key=self.api_key,
-            run_id=self.run_id,
+            run_id=run_id,
             token_file=self.token_file,
             token_url=self.token_url,
             timeout=5.0,
@@ -612,6 +611,7 @@ class DataSourceClient:
 
     def _set_proxy(self):
         flight_host = os.getenv(DOMINO_DATASOURCE_PROXY_FLIGHT_HOST)
+        run_id = os.getenv(DOMINO_RUN_ID, "")
         self.proxy = flight.FlightClient(
             flight_host,
             middleware=[
@@ -620,7 +620,7 @@ class DataSourceClient:
                     self.token_file,
                     self.token_url,
                 ),
-                MetaMiddlewareFactory(self.run_id),
+                MetaMiddlewareFactory(run_id),
             ],
         )
 

--- a/domino_data/data_sources.py
+++ b/domino_data/data_sources.py
@@ -46,6 +46,7 @@ AWS_CREDENTIALS_DEFAULT_LOCATION = "/var/lib/domino/home/.aws/credentials"
 AWS_SHARED_CREDENTIALS_FILE = "AWS_SHARED_CREDENTIALS_FILE"
 DOMINO_API_HOST = "DOMINO_API_HOST"
 DOMINO_API_PROXY = "DOMINO_API_PROXY"
+DOMINO_CLIENT_SOURCE = "DOMINO_CLIENT_SOURCE"
 DOMINO_DATASOURCE_PROXY_HOST = "DOMINO_DATASOURCE_PROXY_HOST"
 DOMINO_DATASOURCE_PROXY_FLIGHT_HOST = "DOMINO_DATASOURCE_PROXY_FLIGHT_HOST"
 DOMINO_RUN_ID = "DOMINO_RUN_ID"
@@ -580,6 +581,8 @@ class DataSourceClient:
             DOMINO_API_PROXY, os.getenv(DOMINO_API_HOST, os.getenv(DOMINO_USER_HOST, ""))
         )
         proxy_host = os.getenv(DOMINO_DATASOURCE_PROXY_HOST, "")
+
+        client_source = os.getenv(DOMINO_CLIENT_SOURCE, "Python")
         run_id = os.getenv(DOMINO_RUN_ID, "")
 
         logger.info(
@@ -593,6 +596,7 @@ class DataSourceClient:
         self.proxy_http = ProxyClient(
             base_url=proxy_host,
             api_key=self.api_key,
+            client_source=client_source,
             run_id=run_id,
             token_file=self.token_file,
             token_url=self.token_url,
@@ -610,6 +614,7 @@ class DataSourceClient:
         )
 
     def _set_proxy(self):
+        client_source = os.getenv(DOMINO_CLIENT_SOURCE, "Python")
         flight_host = os.getenv(DOMINO_DATASOURCE_PROXY_FLIGHT_HOST)
         run_id = os.getenv(DOMINO_RUN_ID, "")
         self.proxy = flight.FlightClient(
@@ -620,7 +625,7 @@ class DataSourceClient:
                     self.token_file,
                     self.token_url,
                 ),
-                MetaMiddlewareFactory(run_id),
+                MetaMiddlewareFactory(client_source, run_id),
             ],
         )
 

--- a/domino_data/data_sources.py
+++ b/domino_data/data_sources.py
@@ -48,9 +48,9 @@ DOMINO_API_HOST = "DOMINO_API_HOST"
 DOMINO_API_PROXY = "DOMINO_API_PROXY"
 DOMINO_DATASOURCE_PROXY_HOST = "DOMINO_DATASOURCE_PROXY_HOST"
 DOMINO_DATASOURCE_PROXY_FLIGHT_HOST = "DOMINO_DATASOURCE_PROXY_FLIGHT_HOST"
+DOMINO_RUN_ID = "DOMINO_RUN_ID"
 DOMINO_USER_API_KEY = "DOMINO_USER_API_KEY"
 DOMINO_USER_HOST = "DOMINO_USER_HOST"
-DOMINO_RUN_ID = "DOMINO_RUN_ID"
 DOMINO_TOKEN_DEFAULT_LOCATION = "/var/lib/domino/home/.api/token"
 DOMINO_TOKEN_FILE = "DOMINO_TOKEN_FILE"
 
@@ -594,6 +594,7 @@ class DataSourceClient:
         self.proxy_http = ProxyClient(
             base_url=proxy_host,
             api_key=self.api_key,
+            run_id=self.run_id,
             token_file=self.token_file,
             token_url=self.token_url,
             timeout=5.0,

--- a/domino_data/meta.py
+++ b/domino_data/meta.py
@@ -1,0 +1,39 @@
+""" Classes to augment headers with metadata for HTTP and Flight requests."""
+
+from typing import Optional
+
+import attr
+from pyarrow import flight
+
+
+@attr.s(auto_attribs=True)
+class MetaMiddlewareFactory(flight.ClientMiddlewareFactory):
+    """Middleware Factory for metadata."""
+
+    run_id: Optional[str] = attr.ib()
+
+    def start_call(self, _):
+        """Called at the start of an RPC."""
+        return MetaMiddleware(self.run_id)
+
+
+@attr.s(auto_attribs=True)
+class MetaMiddleware(flight.ClientMiddleware):
+    """Middleware for authenticating flight requests."""
+
+    run_id: Optional[str] = attr.ib()
+
+    def call_completed(self, _):
+        """No implementation. TODO logging."""
+
+    def received_headers(self, _):
+        """No implementation."""
+
+    def sending_headers(self):
+        """Return metadata headers."""
+        headers = {}
+
+        if self.run_id is not None:
+            headers["x-domino-run-id"] = self.run_id
+
+        return headers

--- a/domino_data/meta.py
+++ b/domino_data/meta.py
@@ -10,17 +10,19 @@ from pyarrow import flight
 class MetaMiddlewareFactory(flight.ClientMiddlewareFactory):
     """Middleware Factory for metadata."""
 
+    client_source: Optional[str] = attr.ib()
     run_id: Optional[str] = attr.ib()
 
     def start_call(self, _):
         """Called at the start of an RPC."""
-        return MetaMiddleware(self.run_id)
+        return MetaMiddleware(self.client_source, self.run_id)
 
 
 @attr.s(auto_attribs=True)
 class MetaMiddleware(flight.ClientMiddleware):
     """Middleware for authenticating flight requests."""
 
+    client_source: Optional[str] = attr.ib()
     run_id: Optional[str] = attr.ib()
 
     def call_completed(self, _):
@@ -33,6 +35,8 @@ class MetaMiddleware(flight.ClientMiddleware):
         """Return metadata headers."""
         headers = {}
 
+        if self.client_source is not None:
+            headers["x-domino-client-source"] = self.client_source
         if self.run_id is not None:
             headers["x-domino-run-id"] = self.run_id
 


### PR DESCRIPTION
## Description

DataSource Audit Trail: need to pass environment variable runId to proxy. Do it from _release-5.7_

## Related Issue

Merge it :)

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/dominodatalab/domino-data/blob/main/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
