### PR TITLE
changed the order of choosing authentication fields

### DIFF
--- a/domino_data/auth.py
+++ b/domino_data/auth.py
@@ -70,9 +70,6 @@ class ProxyClient(AuthenticatedClient):
     """A client that authenticates all requests but with Proxy headers."""
 
     def get_headers(self) -> Dict[str, str]:
-        if self.api_key:
-            self.headers["X-Domino-Api-Key"] = self.api_key
-
         if self.token_url is not None:
             try:
                 jwt = get_jwt_token(self.token_url)
@@ -86,6 +83,9 @@ class ProxyClient(AuthenticatedClient):
             with open(self.token_file, encoding="ascii") as token_file:
                 jwt = token_file.readline().rstrip()
             self.headers["X-Domino-Jwt"] = jwt
+
+        if self.api_key:
+            self.headers["X-Domino-Api-Key"] = self.api_key
 
         return self.headers
 

--- a/domino_data/auth.py
+++ b/domino_data/auth.py
@@ -70,6 +70,9 @@ class ProxyClient(AuthenticatedClient):
     """A client that authenticates all requests but with Proxy headers."""
 
     def get_headers(self) -> Dict[str, str]:
+        if self.api_key:
+            self.headers["X-Domino-Api-Key"] = self.api_key
+
         if self.token_url is not None:
             try:
                 jwt = get_jwt_token(self.token_url)
@@ -83,9 +86,6 @@ class ProxyClient(AuthenticatedClient):
             with open(self.token_file, encoding="ascii") as token_file:
                 jwt = token_file.readline().rstrip()
             self.headers["X-Domino-Jwt"] = jwt
-
-        if self.api_key:
-            self.headers["X-Domino-Api-Key"] = self.api_key
 
         return self.headers
 

--- a/domino_data/auth.py
+++ b/domino_data/auth.py
@@ -46,9 +46,6 @@ class AuthenticatedClient(Client):
 
     def get_headers(self) -> Dict[str, str]:
         """Get headers with either JWT or API Key."""
-        if self.api_key:
-            return {"X-Domino-Api-Key": self.api_key, **self.headers}
-
         if self.token_url is not None:
             try:
                 jwt = get_jwt_token(self.token_url)
@@ -61,6 +58,9 @@ class AuthenticatedClient(Client):
             with open(self.token_file, encoding="ascii") as token_file:
                 jwt = token_file.readline().rstrip()
             return {"Authorization": f"Bearer {jwt}", **self.headers}
+
+        if self.api_key:
+            return {"X-Domino-Api-Key": self.api_key, **self.headers}
 
         return self.headers
 

--- a/tests/feature_store/test_sync.py
+++ b/tests/feature_store/test_sync.py
@@ -51,6 +51,10 @@ def test_sync(feast_repo_root_dir, env, respx_mock, datafx):
 
     # Happy path
     test_feature_store_id = "634e0eee26077433a69b0ec3"
+    respx_mock.get("http://token-proxy/access-token").mock(
+        return_value=httpx.Response(200, content=b"jwt")
+    )
+
     respx_mock.post("http://domino/featurestore/featureview").mock(
         return_value=httpx.Response(200),
     )


### PR DESCRIPTION
## Description

When authenticating with data source proxy service, the jwt token takes precedence over the api key.

## Related Issue

https://dominodatalab.atlassian.net/browse/DOM-49784

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/dominodatalab/domino-data/blob/main/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
