### PR TITLE
Fix pageSize to page_size and regenerate client

### DIFF
--- a/datasource_api_client/models/list_request.py
+++ b/datasource_api_client/models/list_request.py
@@ -52,7 +52,7 @@ class ListRequest:
         if credential_overwrites is not UNSET:
             field_dict["credentialOverwrites"] = credential_overwrites
         if page_size is not UNSET:
-            field_dict["pageSize"] = page_size
+            field_dict["page_size"] = page_size
 
         return field_dict
 
@@ -77,7 +77,7 @@ class ListRequest:
         else:
             credential_overwrites = DatasourceConfig.from_dict(_credential_overwrites)
 
-        page_size = d.pop("pageSize", UNSET)
+        page_size = d.pop("page_size", UNSET)
 
         list_request = cls(
             datasource_id=datasource_id,

--- a/openapi/datasource.yaml
+++ b/openapi/datasource.yaml
@@ -325,7 +325,7 @@ components:
           type: string
         prefix:
           type: string
-        pageSize:
+        page_size:  # Currently using camel_case in datasource-proxy
           type: integer
       required:
         - datasourceId

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,6 @@ import logging
 
 import pyarrow
 import pytest
-from _pytest.logging import caplog as _caplog
 from loguru import logger
 
 # TODO This method is deprecated and should be refactored using `env`

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,7 +101,7 @@ def datafx():
 
 
 @pytest.fixture
-def caplog(_caplog):
+def caplog(caplog):
     """Capture loguru log fixture"""
 
     class PropogateHandler(logging.Handler):
@@ -109,4 +109,4 @@ def caplog(_caplog):
             logging.getLogger(record.name).handle(record)
 
     logger.add(PropogateHandler(), format="{message}")
-    yield _caplog
+    yield caplog


### PR DESCRIPTION
## Description

Parameter page_size using camel case in the backend but not in the client.

## Related Issue

https://dominodatalab.atlassian.net/browse/DOM-53567

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CONTRIBUTING.md`](https://github.com/dominodatalab/domino-data/blob/main/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
