### PR TITLE
Retry getting jwt token for reading timeout

### DIFF
--- a/domino_data/auth.py
+++ b/domino_data/auth.py
@@ -13,6 +13,7 @@ from datasource_api_client.client import Client
 
 
 @backoff.on_exception(backoff.expo, httpx.HTTPStatusError, max_time=2)
+@backoff.on_exception(backoff.expo, httpx.ReadTimeout, max_tries=2)
 def get_jwt_token(url: str) -> str:
     """Gets a domino token from local sidecar API.
 


### PR DESCRIPTION
## Description

Seeing the reading timeout in the nightly system test. It's an exception safe to retry.

## Related Issue

https://dominodatalab.atlassian.net/browse/DOM-56006

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/dominodatalab/domino-data/blob/main/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
