### PR TITLE
Fix the get datasource issue with no run id

### DIFF
--- a/domino_data/data_sources.py
+++ b/domino_data/data_sources.py
@@ -591,7 +591,7 @@ class DataSourceClient:
         proxy_host = os.getenv(DOMINO_DATASOURCE_PROXY_HOST, "")
 
         client_source = os.getenv(DOMINO_CLIENT_SOURCE, "Python")
-        run_id = os.getenv(DOMINO_RUN_ID, "")
+        run_id = os.getenv(DOMINO_RUN_ID)
 
         logger.info(
             "initializing datasource client with hosts",
@@ -624,7 +624,7 @@ class DataSourceClient:
     def _set_proxy(self):
         client_source = os.getenv(DOMINO_CLIENT_SOURCE, "Python")
         flight_host = os.getenv(DOMINO_DATASOURCE_PROXY_FLIGHT_HOST)
-        run_id = os.getenv(DOMINO_RUN_ID, "")
+        run_id = os.getenv(DOMINO_RUN_ID)
         self.proxy = flight.FlightClient(
             flight_host,
             middleware=[
@@ -651,7 +651,7 @@ class DataSourceClient:
         """
         logger.info("get_datasource", datasource_name=name)
 
-        run_id = os.getenv(DOMINO_RUN_ID, "")
+        run_id = os.getenv(DOMINO_RUN_ID)
         response = get_datasource_by_name.sync_detailed(
             name,
             client=self.domino.with_auth_headers(),

--- a/domino_data/data_sources.py
+++ b/domino_data/data_sources.py
@@ -591,7 +591,7 @@ class DataSourceClient:
         proxy_host = os.getenv(DOMINO_DATASOURCE_PROXY_HOST, "")
 
         client_source = os.getenv(DOMINO_CLIENT_SOURCE, "Python")
-        run_id = os.getenv(DOMINO_RUN_ID)
+        run_id = os.getenv(DOMINO_RUN_ID, "")
 
         logger.info(
             "initializing datasource client with hosts",
@@ -624,7 +624,7 @@ class DataSourceClient:
     def _set_proxy(self):
         client_source = os.getenv(DOMINO_CLIENT_SOURCE, "Python")
         flight_host = os.getenv(DOMINO_DATASOURCE_PROXY_FLIGHT_HOST)
-        run_id = os.getenv(DOMINO_RUN_ID)
+        run_id = os.getenv(DOMINO_RUN_ID, "")
         self.proxy = flight.FlightClient(
             flight_host,
             middleware=[

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "dominodatalab-data"
-version = "5.11.1"
+version = "5.11.2"
 description = "Domino Data API for interacting with Domino Data features"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Description
Fix the wrong default domino run id when getting the data source.  

This was introduced when fixing the build issue when generating the client using a particular version of open api generator.  Fortunately, the final generated code doesn't require a default value to be present to pass the build. 

## Related Issue

https://dominodatalab.atlassian.net/browse/DOM-57725

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/dominodatalab/domino-data/blob/main/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
