### PR TITLE
DOM-63173 keeping subdirectories in the list returned

### DIFF
--- a/domino_data/data_sources.py
+++ b/domino_data/data_sources.py
@@ -451,7 +451,6 @@ class ObjectStoreDatasource(Datasource):
                 key=key,
             )
             for key in keys
-            if not key.endswith("/")
         ]
 
     def get_key_url(self, object_key: str, is_read_write: bool = False) -> str:


### PR DESCRIPTION
## Description

the listObjectsV2 AWS API returns subdirectories as separate objects in the list of objects returned, but we omit them from the list returned to the user. 

We should keep these entries in the list returned to the user since this will cause page_size parameter to appear incorrect. I also think it's important to keep the same behavior as the native API (and boto3 API has the same behavior)

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/dominodatalab/domino-data/blob/main/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
