### PR TITLE
Fix the get datasource issue with no run id (#147)

### DIFF
--- a/domino_data/data_sources.py
+++ b/domino_data/data_sources.py
@@ -653,7 +653,7 @@ class DataSourceClient:
         """
         logger.info("get_datasource", datasource_name=name)
 
-        run_id = os.getenv(DOMINO_RUN_ID, "")
+        run_id = os.getenv(DOMINO_RUN_ID)
         response = get_datasource_by_name.sync_detailed(
             name,
             client=self.domino.with_auth_headers(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "dominodatalab-data"
-version = "6.0.0.dev1"
+version = "6.0.0"
 description = "Domino Data API for interacting with Domino Data features"
 readme = "README.md"
 authors = [


### PR DESCRIPTION
## Description

Port the fix of domino run id from 5.11 to the main branch 

Fix the wrong default domino run id when getting the data source.  

## Related Issue

https://dominodatalab.atlassian.net/browse/DOM-57725
https://dominodatalab.atlassian.net/browse/DOM-62827

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [x] 🔧 Bug fix (non-breaking change which fixes an issue)
- [ ] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/dominodatalab/domino-data/blob/main/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
