### PR TITLE
DOM-63821 removing "preview" from docs

### DIFF
--- a/docs/source/domino_data.rst
+++ b/docs/source/domino_data.rst
@@ -1,8 +1,6 @@
 Domino Data API
 ===============
 
-.. NOTE:: These APIs are a preview feature, not officially supported.
-
 Training Set
 ------------
 


### PR DESCRIPTION
## Description

Need to remove preview note from this docs page: https://python-docs.dominodatalab.com/en/latest/domino_data.html

## Related Issue

<!-- If your PR refers to a related issue, link it here. -->

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] I've read the [`CONTRIBUTING.md`](https://github.com/dominodatalab/domino-data/blob/main/CONTRIBUTING.md) guide.
- [ ] I've updated the code style using `make codestyle`.
- [ ] I've written tests for all new methods and classes that I created.
- [ ] I've written the docstring in Google format for all the methods and classes that I used.
