### PR TITLE
[DOM-67034] Add support for overriding dataset config

### DIFF
--- a/domino_data/datasets.py
+++ b/domino_data/datasets.py
@@ -14,6 +14,7 @@ import domino_data.configuration_gen
 from domino_data.data_sources import DataSourceClient, ObjectStoreDatasource
 
 from .auth import AuthenticatedClient, get_jwt_token
+from .configuration_gen import Config, DatasetConfig
 from .logging import logger
 from .transfer import MAX_WORKERS, BlobTransfer
 
@@ -162,6 +163,18 @@ class Dataset:
     def pool_manager(self) -> urllib3.PoolManager:
         """Urllib3 pool manager for range downloads."""
         return urllib3.PoolManager()
+
+    def update(self, config: DatasetConfig) -> None:
+        """Store configuration override for future query calls.
+
+        Args:
+            config: dataset config class
+        """
+        self.datasource._config_override = config
+
+    def reset_config(self) -> None:
+        """Reset the configuration override."""
+        self.datasource._config_override = Config()
 
     def File(self, file_name: str) -> _File:  # pylint: disable=invalid-name
         """Return a file with given name and dataset client."""

--- a/tests/cassettes/test_dataset/test_config_override.yaml
+++ b/tests/cassettes/test_dataset/test_config_override.yaml
@@ -1,0 +1,119 @@
+interactions:
+- request:
+    body: ''
+    headers:
+      accept:
+      - application/json
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      host:
+      - mcetin5238.workbench-accessdata-team-sandbox.domino.tech
+      user-agent:
+      - python-httpx/0.18.2
+      x-domino-api-key:
+      - b9b339d163152218be8982769fec897561a57888aca799de328d3643e5d74148
+    method: GET
+    uri: https://mcetin5238.workbench-accessdata-team-sandbox.domino.tech/v4/datasource/name/dataset-test
+  response:
+    content: '{"id":"61677736fa49a22d0025804d","name":"dataset-test","description":"Generic dataset
+      data source for system tests","ownerId":"61677430fa49a22d00258025","ownerInfo":{"ownerName":"system-test","ownerEmail":"systester@dominodatalab.com","isOwnerAdmin":false},"addedBy":{"61677649fa49a22d00258039":"system-test"},"authType": "NoAuth","dataSourceType":"DatasetConfig","config":{"snapshotID":"67acfad445df4d5f4d143e9d","datasetID":"67acfad445df4d5f4d143e9e"},"credentialType":"Individual","lastUpdated":1634250138905,"lastUpdatedBy":"6167728efa49a22d0025801c","lastAccessed":{"61677649fa49a22d00258039":1634170729467},"addedToProjectTimeMap":{"61677649fa49a22d00258039":1634170729467},"isEveryone":false,"userIds":["6167728efa49a22d0025801c"],"projectIds":["61677649fa49a22d00258039"],"adminInfo":{"projectNames":{},"projectIdOwnerUsernameMap":{},"projectLastActiveMap":{"61677649fa49a22d00258039":"2021-10-14T00:18:45.051Z"}},"status":"Active"}'
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Cache-Control:
+      - no-cache, no-store, must-revalidate, max-age=0
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - frame-ancestors 'self'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Oct 2021 18:12:49 GMT
+      Domino-Server:
+      - nginx-ingress,nucleus,
+      Play-Processing-Time:
+      - '18'
+      Set-Cookie:
+      - dominoSession=6bc9b873-a398-4b22-9f8d-d318322be0ba; Max-Age=78840000; Expires=Mon,
+        15 Apr 2024 06:12:49 GMT; Path=/; Domain=.mcetin5238.workbench-accessdata-team-sandbox.domino.tech;
+        Secure; HTTPOnly
+      Strict-Transport-Security:
+      - max-age=15768000
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Origin
+      X-Frame-Options:
+      - SAMEORIGIN
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: '{"datasourceId": "61677736fa49a22d0025804d", "prefix": "", "pageSize": 1000, "configOverwrites": {}, "credentialOverwrites": {}}'
+    headers:
+      accept:
+      - '*/*'
+      accept-encoding:
+      - gzip, deflate
+      connection:
+      - keep-alive
+      content-length:
+      - '131'
+      content-type:
+      - application/json
+      host:
+      - localhost:8000
+      user-agent:
+      - python-httpx/0.18.2
+      x-domino-api-key:
+      - b9b339d163152218be8982769fec897561a57888aca799de328d3643e5d74148
+    method: POST
+    uri: http://localhost:8000/objectstore/list
+  response:
+    content: '["diabetes.csv","diabetes_changed.csv"]'
+    headers:
+      Content-Length:
+      - '40'
+      Content-Type:
+      - application/json
+      Date:
+      - Fri, 15 Oct 2021 18:12:49 GMT
+    http_version: HTTP/1.1
+    status_code: 200
+- request:
+    body: '{"datasourceId": "61677736fa49a22d0025804d", "prefix": "", "pageSize": 1, "configOverwrites": {"snapshotId: "68011fa7b4ec1d6d4f81df7e"}, "credentialOverwrites": {}}'
+    headers:
+      accept:
+        - '*/*'
+      accept-encoding:
+        - gzip, deflate
+      connection:
+        - keep-alive
+      content-length:
+        - '128'
+      content-type:
+        - application/json
+      host:
+        - localhost:8000
+      user-agent:
+        - python-httpx/0.18.2
+      x-domino-api-key:
+        - b9b339d163152218be8982769fec897561a57888aca799de328d3643e5d74148
+    method: POST
+    uri: http://localhost:8000/objectstore/list
+  response:
+    content: '["diabetes.csv"]'
+    headers:
+      Content-Length:
+        - '25'
+      Content-Type:
+        - application/json
+      Date:
+        - Fri, 15 Oct 2021 18:12:49 GMT
+    http_version: HTTP/1.1
+    status_code: 200
+version: 1

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -178,3 +178,22 @@ def test_download_fileobj(env, respx_mock, datafx):
     dataset.download_fileobj("file.png", mock_fileobj)
 
     assert mock_fileobj.getvalue() == mock_content
+
+
+# Configuration override
+@pytest.mark.vcr
+def test_config_override():
+    """Client get list of files in a dataset."""
+    dataset_test = ds.DatasetClient().get_dataset("dataset-test")
+
+    files = [file.name for file in dataset_test.list_files("", 1000)]
+
+    assert files == ["diabetes.csv", "diabetes_changed.csv"]
+
+    config = ds.DatasetConfig(snapshot_id="68011fa7b4ec1d6d4f81df7e")
+
+    dataset_test.update(config)
+
+    files = [file.name for file in dataset_test.list_files("", 1000)]
+
+    assert files == ["diabetes.csv"]


### PR DESCRIPTION
## Description

<!-- Add a more detailed description of the changes if needed. -->

## Related Issue

https://dominodatalab.atlassian.net/browse/DOM-67034

## Type of Change

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [ ] 📚 Examples / docs / tutorials / dependencies update
- [ ] 🔧 Bug fix (non-breaking change which fixes an issue)
- [x] 🥂 Improvement (non-breaking change which improves an existing feature)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🔐 Security fix

## Checklist

<!-- Mark with an `x` all the checkboxes that apply (like `[x]`) -->

- [x] I've read the [`CONTRIBUTING.md`](https://github.com/dominodatalab/domino-data/blob/main/CONTRIBUTING.md) guide.
- [x] I've updated the code style using `make codestyle`.
- [x] I've written tests for all new methods and classes that I created.
- [x] I've written the docstring in Google format for all the methods and classes that I used.
